### PR TITLE
Fix: Handle possible null in fileCache access

### DIFF
--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
           if (manifest) {
             await sendProgress({ type: 'status', message: '🔍 Creating search plan...' });
             
-            const fileContents = global.sandboxState.fileCache.files;
+            const fileContents = global.sandboxState.fileCache?.files || {};
             console.log('[generate-ai-code-stream] Files available for search:', Object.keys(fileContents).length);
             
             // STEP 1: Get search plan from AI


### PR DESCRIPTION
The build was failing with a TypeScript error: "'global.sandboxState.fileCache' is possibly 'null'." This commit fixes the error by using optional chaining (`?.`) and providing a default empty object (`{}`) when accessing `global.sandboxState.fileCache.files`. This makes the code more robust and prevents the build from failing.